### PR TITLE
Add supported fields to Authenticate struct type

### DIFF
--- a/certverify/pool.go
+++ b/certverify/pool.go
@@ -11,13 +11,19 @@ type PoolVerifier struct {
 }
 
 // NewPoolVerifier creates a new Verifier
-func NewPoolVerifier(rootsPEM []byte, keyUsages ...x509.ExtKeyUsage) (*PoolVerifier, error) {
+func NewPoolVerifier(rootsPEM []byte, intsPEM []byte, keyUsages ...x509.ExtKeyUsage) (*PoolVerifier, error) {
 	opts := x509.VerifyOptions{
 		KeyUsages: keyUsages,
 		Roots:     x509.NewCertPool(),
 	}
 	if len(rootsPEM) == 0 || !opts.Roots.AppendCertsFromPEM(rootsPEM) {
 		return nil, errors.New("could not append root CA(s)")
+	}
+	if len(intsPEM) > 0 {
+		opts.Intermediates = x509.NewCertPool()
+		if !opts.Intermediates.AppendCertsFromPEM(intsPEM) {
+			return nil, errors.New("could not append intermediate CA(s)")
+		}
 	}
 	return &PoolVerifier{
 		verifyOpts: opts,

--- a/cmd/nanomdm/main.go
+++ b/cmd/nanomdm/main.go
@@ -50,7 +50,8 @@ func main() {
 		flListen     = flag.String("listen", ":9000", "HTTP listen address")
 		flAPIKey     = flag.String("api", "", "API key for API endpoints")
 		flVersion    = flag.Bool("version", false, "print version")
-		flRootsPath  = flag.String("ca", "", "path to CA cert for verification")
+		flRootsPath  = flag.String("ca", "", "path to PEM CA cert(s)")
+		flIntsPath   = flag.String("intermediate", "", "path to PEM intermediate cert(s)")
 		flWebhook    = flag.String("webhook-url", "", "URL to send requests to")
 		flCertHeader = flag.String("cert-header", "", "HTTP header containing URL-escaped TLS client certificate")
 		flDebug      = flag.Bool("debug", false, "log debug messages")
@@ -81,7 +82,11 @@ func main() {
 	if err != nil {
 		stdlog.Fatal(err)
 	}
-	verifier, err := certverify.NewPoolVerifier(caPEM, x509.ExtKeyUsageClientAuth)
+	intsPEM, err := os.ReadFile(*flIntsPath)
+	if err != nil {
+		stdlog.Fatal(err)
+	}
+	verifier, err := certverify.NewPoolVerifier(caPEM, intsPEM, x509.ExtKeyUsageClientAuth)
 	if err != nil {
 		stdlog.Fatal(err)
 	}

--- a/cmd/nanomdm/main.go
+++ b/cmd/nanomdm/main.go
@@ -82,9 +82,12 @@ func main() {
 	if err != nil {
 		stdlog.Fatal(err)
 	}
-	intsPEM, err := os.ReadFile(*flIntsPath)
-	if err != nil {
-		stdlog.Fatal(err)
+	var intsPEM []byte
+	if *flIntsPath != "" {
+		intsPEM, err = os.ReadFile(*flIntsPath)
+		if err != nil {
+			stdlog.Fatal(err)
+		}
 	}
 	verifier, err := certverify.NewPoolVerifier(caPEM, intsPEM, x509.ExtKeyUsageClientAuth)
 	if err != nil {

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -28,9 +28,15 @@ API authorization in NanoMDM is simply HTTP Basic authentication using "nanomdm"
 
 ### -ca string
 
-* Path to CA cert for verification
+* path to PEM CA cert(s)
 
-NanoMDM validates that the device identity certificate is issued from specific CAs. This switch is the path to a file of PEM-encoded CAs to validate against.
+NanoMDM validates that the device identity certificate is issued from specific CAs. This switch is the path to a file of PEM-encoded CAs to validate enrollments against.
+
+### -intermediate string
+
+* path to PEM intermediate cert(s)
+
+NanoMDM validates that the device identity certificate is issued from specific CAs. This switch is the path to a file of PEM-encoded intermediate certificates that can be used to build a chain of trust to the CAs to validate enrollments against.
 
 ### -cert-header string
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/micromdm/nanomdm
 
-go 1.15
+go 1.17
 
 require (
 	github.com/RobotsAndPencils/buford v0.14.0
@@ -8,4 +8,9 @@ require (
 	github.com/groob/plist v0.0.0-20220217120414-63fa881b19a5
 	github.com/lib/pq v1.10.6
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
+)
+
+require (
+	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb // indirect
+	golang.org/x/text v0.3.0 // indirect
 )

--- a/mdm/checkin.go
+++ b/mdm/checkin.go
@@ -23,11 +23,15 @@ type Authenticate struct {
 	Topic string
 	Raw   []byte `plist:"-"` // Original Authenticate XML plist
 
+	// Additional fields required in AuthenticateRequest as specified
+	// in the Apple documentation.
+	DeviceName string
+	Model      string
+	ModelName  string
+
 	// Fields that may be present but are not strictly required for the
 	// operation of the MDM protocol. Nice-to-haves.
 	SerialNumber string
-	Model        string
-	ModelName    string
 }
 
 type b64Data []byte

--- a/mdm/checkin.go
+++ b/mdm/checkin.go
@@ -149,6 +149,9 @@ func (w *checkinUnmarshaller) UnmarshalPlist(f func(interface{}) error) error {
 func DecodeCheckin(rawMessage []byte) (message interface{}, err error) {
 	w := &checkinUnmarshaller{raw: rawMessage}
 	err = plist.Unmarshal(rawMessage, w)
+	if err != nil {
+		err = &ParseError{Err: err, Content: rawMessage}
+	}
 	message = w.message
 	return
 }

--- a/mdm/checkin.go
+++ b/mdm/checkin.go
@@ -26,6 +26,8 @@ type Authenticate struct {
 	// Fields that may be present but are not strictly required for the
 	// operation of the MDM protocol. Nice-to-haves.
 	SerialNumber string
+	Model        string
+	ModelName    string
 }
 
 type b64Data []byte

--- a/mdm/command.go
+++ b/mdm/command.go
@@ -35,7 +35,7 @@ func DecodeCommandResults(rawResults []byte) (results *CommandResults, err error
 	results = new(CommandResults)
 	err = plist.Unmarshal(rawResults, results)
 	if err != nil {
-		return
+		return nil, &ParseError{Err: err, Content: rawResults}
 	}
 	results.Raw = rawResults
 	if results.Status == "" {
@@ -58,7 +58,7 @@ func DecodeCommand(rawCommand []byte) (command *Command, err error) {
 	command = new(Command)
 	err = plist.Unmarshal(rawCommand, command)
 	if err != nil {
-		return
+		return nil, &ParseError{Err: err, Content: rawCommand}
 	}
 	command.Raw = rawCommand
 	if command.CommandUUID == "" || command.Command.RequestType == "" {

--- a/mdm/mdm.go
+++ b/mdm/mdm.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
+	"fmt"
 )
 
 // Enrollment represents the various enrollment-related data sent with requests.
@@ -58,4 +59,20 @@ func (r *Request) Clone() *Request {
 	r2 := new(Request)
 	*r2 = *r
 	return r2
+}
+
+// ParseError represents a failure to parse an MDM structure (usually Apple Plist)
+type ParseError struct {
+	Err     error
+	Content []byte
+}
+
+// Unwrap returns the underlying error of the ParseError
+func (e *ParseError) Unwrap() error {
+	return e.Err
+}
+
+// Error formats the ParseError as a string
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("parse error: %v: raw content: %v", e.Err, string(e.Content))
 }

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -4,6 +4,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	_ "embed"
 	"errors"
 	"fmt"
 
@@ -12,6 +13,11 @@ import (
 	"github.com/micromdm/nanomdm/log/ctxlog"
 	"github.com/micromdm/nanomdm/mdm"
 )
+
+// Schema holds the schema for the NanoMDM MySQL storage.
+//
+//go:embed schema.sql
+var Schema string
 
 var ErrNoCert = errors.New("no certificate in MDM Request")
 

--- a/storage/pgsql/postgresql.go
+++ b/storage/pgsql/postgresql.go
@@ -4,6 +4,7 @@ package pgsql
 import (
 	"context"
 	"database/sql"
+	_ "embed"
 	"errors"
 	"fmt"
 
@@ -12,6 +13,11 @@ import (
 	"github.com/micromdm/nanomdm/log/ctxlog"
 	"github.com/micromdm/nanomdm/mdm"
 )
+
+// Schema holds the schema for the NanoMDM PostgresSQL storage.
+//
+//go:embed schema.sql
+var Schema string
 
 var ErrNoCert = errors.New("no certificate in MDM Request")
 


### PR DESCRIPTION
- Adds `DeviceName`, `Model`, and `ModelName` to `Authenticate` struct, which are required fields for an `AuthenticateRequest` according to Apple's [documentation](https://developer.apple.com/documentation/devicemanagement/authenticaterequest) 