### PR TITLE
Add supported fields to Authenticate struct type

### DIFF
--- a/mdm/checkin.go
+++ b/mdm/checkin.go
@@ -23,6 +23,12 @@ type Authenticate struct {
 	Topic string
 	Raw   []byte `plist:"-"` // Original Authenticate XML plist
 
+	// Additional fields required in AuthenticateRequest as specified
+	// in the Apple documentation.
+	DeviceName string
+	Model      string
+	ModelName  string
+
 	// Fields that may be present but are not strictly required for the
 	// operation of the MDM protocol. Nice-to-haves.
 	SerialNumber string


### PR DESCRIPTION
Adds DeviceName, Model, and ModelName to Authenticate struct, which are required fields for an AuthenticateRequest according to Apple's [documentation](https://developer.apple.com/documentation/devicemanagement/authenticaterequest)